### PR TITLE
fix link issue on macOS

### DIFF
--- a/CMakePresetsBase.json
+++ b/CMakePresetsBase.json
@@ -8,6 +8,8 @@
       "cacheVariables": {
         "MINIGLOG": "ON",
         "GFLAGS": "OFF",
+        "ACCELERATESPARSE": "OFF",
+        "LAPACK": "OFF",
         "XP_NAMESPACE": "xpro"
       }
     }


### PR DESCRIPTION
CMakePresetsBase: disable ACCELERATESPARSE, LAPACK
issue https://github.com/externpro/externpro/issues/170#issuecomment-3246256477
